### PR TITLE
Update clang-format-check.yml

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - main
-  push:
-    branches:
-      - main
       
 jobs:
   formatting-check:


### PR DESCRIPTION
nao precisa rodar no merge com a main, só na abertura do PR