### PR TITLE
Simplify clang-format workflow by removing change detection

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -18,21 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Detect changes on relevant files
-        id: changed-files
-        uses: tj-actions/changed-files@v46
-        with:
-          files: |
-            Codigos/**/*.cpp
-
       - name: Run clang-format style check for C++ programs
-        if: steps.changed-files.outputs.any_changed == 'true'
         uses: jidicula/clang-format-action@v4.12.0
         with:
           clang-format-version: '18'
           check-path: 'Codigos'
           fallback-style: 'LLVM'
-
-      - name: No relevant changes
-        if: steps.changed-files.outputs.any_changed != 'true'
-        run: echo "Nenhum .cpp alterado, check passou automaticamente."


### PR DESCRIPTION
Removed unnecessary steps for detecting changed files and simplified the workflow.